### PR TITLE
feat: configure global scatter parameter

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+"""Global configuration for simulation and inference parameters."""
+
+# Measurement scatter for observed quantities (dex or mag)
+OBS_SCATTER: float = 0.1
+

--- a/likelihood.py
+++ b/likelihood.py
@@ -24,6 +24,7 @@ from .utils import mag_likelihood, selection_function
 from .cached_A import cached_A_interp
 from .make_tabulate.make_tabulate import LensGrid, tabulate_likelihood_grids
 from .mock_generator.mass_sampler import MODEL_PARAMS
+from .config import OBS_SCATTER
 
 
 # Parameters of the generative model (default: deVauc) used for sizes
@@ -56,13 +57,16 @@ def precompute_grids(
     logMh_grid: Iterable[float],
     zl: float = 0.3,
     zs: float = 2.0,
-    sigma_m: float = 0.1,
+    sigma_m: float | None = None,
     m_lim: float = 26.5,
 ) -> list[LensGrid]:
     """Convenience wrapper around :func:`tabulate_likelihood_grids`.
 
     Parameters are passed directly to :func:`tabulate_likelihood_grids`.
     """
+
+    if sigma_m is None:
+        sigma_m = OBS_SCATTER
 
     return tabulate_likelihood_grids(
         mock_observed_data,
@@ -147,7 +151,7 @@ def _single_lens_likelihood(
     p_logalpha = norm.pdf(logalpha_grid, loc=mu_alpha, scale=sigma_alpha)
 
 
-    scatter_Mstar = 0.1  # Measurement scatter of 0.1 dex
+    scatter_Mstar = OBS_SCATTER  # Measurement scatter
 
 
 
@@ -155,7 +159,7 @@ def _single_lens_likelihood(
     p_Mstar = norm.pdf(
         logM_sps_obs,
         loc=logM_star[None, :] - logalpha_grid[:, None],
-        scale=scatter_Mstar,  # Measurement scatter of 0.1 dex
+        scale=scatter_Mstar,  # Measurement scatter
     )
 
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from .mock_generator.mock_generator import run_mock_simulation
 from .likelihood import precompute_grids
 from .run_mcmc import run_mcmc
 from .plotting import plot_chain
+from . import config
 import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use("TkAgg")  # 或者 Qt5Agg, MacOSX
@@ -17,6 +18,9 @@ matplotlib.use("TkAgg")  # 或者 Qt5Agg, MacOSX
 # scatter_Mstar = 0.01
 
 def main() -> None:
+    scatter = 0.1  # Global measurement scatter (dex or mag)
+    config.OBS_SCATTER = scatter
+
     # Generate mock data for  samples
     mock_lens_data, mock_observed_data = run_mock_simulation(1000)
     logM_sps_obs = mock_observed_data["logM_star_sps_observed"].values
@@ -25,7 +29,7 @@ def main() -> None:
 
     # Precompute grids on halo mass
     logMh_grid = np.linspace(11.5, 14.0, 100)
-    grids = precompute_grids(mock_observed_data, logMh_grid)
+    grids = precompute_grids(mock_observed_data, logMh_grid, sigma_m=scatter)
     nsteps = 6000
     # Run MCMC sampling for 10000 steps
     sampler = run_mcmc(grids, logM_sps_obs, nsteps=nsteps, nwalkers=20, backend_file="chains_eta_new_table_no_eta_variedms10006_sigma001.h5", parallel=True, nproc=mp.cpu_count()-3)

--- a/mock_generator/lens_properties.py
+++ b/mock_generator/lens_properties.py
@@ -1,6 +1,7 @@
 from .lens_solver import solve_single_lens
 from .lens_model import kpc_to_arcsec, LensModel
 from ..sl_cosmology import Dang
+from ..config import OBS_SCATTER
 import numpy as np
 
 # SPS PARAMETER
@@ -64,13 +65,13 @@ def observed_data(input_df, caustic=False, scatter_Mstar=None):
 
    # magnificationA, magnificationB = properties['magnificationA'], properties['magnificationB']
    
-   scatter_mag = 0.1  # [mag] 源光度的散射
+   scatter_mag = OBS_SCATTER  # [mag] 源光度的散射
    properties['scatter_mag'] = scatter_mag
    magnitude_observedA = m_s - 2.5 * np.log10(properties['magnificationA']) + np.random.normal(loc=0.0, scale=scatter_mag)
    magnitude_observedB = m_s - 2.5 * np.log10(properties['magnificationB']) + np.random.normal(loc=0.0, scale=scatter_mag)
 
    if scatter_Mstar is None:
-       scatter_Mstar = 0.1
+       scatter_Mstar = OBS_SCATTER
    # scatter_Mstar = 0.1  # [Msun] 源质量的散射
 
 


### PR DESCRIPTION
## Summary
- add config module holding `OBS_SCATTER`
- drive mock generation and likelihood scatter from shared config
- set scatter in main for consistent simulation and inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934334fa5c832db156da15004df16e